### PR TITLE
Enable Client PasswordHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ func main() {
 	server := "https://prtg.paessler.com"
 	username := "demo"
 	password := "demodemo"
-	// or
-	passwordHash := "passhash"
 
-	client := prtg.NewClient(server, username, password, passwordHash)
+	client := prtg.NewClient(server, username, password)
 	prtgVersion, err := client.GetPrtgVersion()
 	if err != nil {
 		log.Println(err)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ func main() {
 	server := "https://prtg.paessler.com"
 	username := "demo"
 	password := "demodemo"
+	// or
+	passwordHash := "passhash"
 
-	client := prtg.NewClient(server, username, password)
+	client := prtg.NewClient(server, username, password, passwordHash)
 	prtgVersion, err := client.GetPrtgVersion()
 	if err != nil {
 		log.Println(err)

--- a/_example/auth_with_password_hash_example.go
+++ b/_example/auth_with_password_hash_example.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+
+	"github.com/haidlir/golang-prtg-api-wrapper/prtg-api"
+)
+
+func main() {
+	// Configuration
+	server := "https://prtg.paessler.com"
+	username := "demo"
+	passwordHash := "000000000"
+
+	client := prtg.NewClientWithHashedPass(server, username, passwordHash)
+	prtgVersion, err := client.GetPrtgVersion()
+	if err != nil {
+		log.Println(err)
+	} else {
+		log.Printf("The version of PRTG on %v is %v.", server, prtgVersion)
+	}
+}

--- a/prtg-api/prtg_api.go
+++ b/prtg-api/prtg_api.go
@@ -19,6 +19,9 @@ type Client struct {
 	// Any account's password of PRTG (mandatory)
 	Password string
 
+	// Any account's password hash of PRTG
+	PasswordHash string
+
 	// Timeout Context in millisecond
 	Timeout int64
 }
@@ -57,11 +60,13 @@ const (
 // server := "http://localhost"
 // username := "user"
 // password := "pass"
-func NewClient(server, username, password string) *Client {
+// passwordHash := "000000000"
+func NewClient(server, username, password, passwordHash string) *Client {
 	instance := new(Client)
 	instance.Server = server
 	instance.Username = username
 	instance.Password = password
+	instance.PasswordHash = passwordHash
 	instance.Timeout = 10000
 	return instance
 }
@@ -78,7 +83,12 @@ func (c *Client) SetContextTimeout(timeout int64) {
 func (c *Client) getTemplateUrlQuery() *url.Values {
 	q := url.Values{}
 	q.Set("username", c.Username)
-	q.Set("password", c.Password)
+	if c.Password != "" {
+		q.Set("password", c.Password)
+	}
+	if c.PasswordHash != "" {
+		q.Set("passhash", c.PasswordHash)
+	}
 	return &q
 }
 

--- a/prtg-api/prtg_api.go
+++ b/prtg-api/prtg_api.go
@@ -60,12 +60,24 @@ const (
 // server := "http://localhost"
 // username := "user"
 // password := "pass"
-// passwordHash := "000000000"
-func NewClient(server, username, password, passwordHash string) *Client {
+func NewClient(server, username, password string) *Client {
 	instance := new(Client)
 	instance.Server = server
 	instance.Username = username
 	instance.Password = password
+	instance.Timeout = 10000
+	return instance
+}
+
+// NewClientWithHashedPass takes server, username, passwordHash and returns client's instance.
+// input format:
+// server := "http://localhost"
+// username := "user"
+// passwordHash := "000000000"
+func NewClientWithHashedPass(server, username, passwordHash string) *Client {
+	instance := new(Client)
+	instance.Server = server
+	instance.Username = username
 	instance.PasswordHash = passwordHash
 	instance.Timeout = 10000
 	return instance

--- a/prtg-api/prtg_api_test.go
+++ b/prtg-api/prtg_api_test.go
@@ -16,16 +16,17 @@ func TestNewClient(t *testing.T) {
 	server := "http://localhost"
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 
 	// Trying to create new client
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 	if client == nil {
 		t.Error("A new connection object must have been made")
 	}
 
 	// Trying to change the server
 	server = "http://127.0.0.1"
-	client = NewClient(server, username, password)
+	client = NewClient(server, username, password, passwordHash)
 	if client.Server != "http://127.0.0.1" {
 		t.Errorf("Server is %v instead of http://127.0.0.1", client.Server)
 	}
@@ -35,7 +36,8 @@ func TestSetContextTimeout(t *testing.T) {
 	server := "http://localhost"
 	username := "user"
 	password := "pass"
-	client := NewClient(server, username, password)
+	passwordHash := "passhash"
+	client := NewClient(server, username, password, passwordHash)
 
 	// Check whether client contains default context timeout or not.
 	if client.Timeout != 10000 {
@@ -71,7 +73,7 @@ func TestGetCompleteUrl(t *testing.T) {
 	servers := []string{" http://localhost", "localhost"}
 
 	for _, server := range servers {
-		client := NewClient(server, "", "")
+		client := NewClient(server, "", "", "")
 
 		_, err := client.GetPrtgVersion()
 		if err == nil {
@@ -127,7 +129,8 @@ func TestGetPrtgVersion(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	client := NewClient(server, username, password)
+	passwordHash := "passhash"
+	client := NewClient(server, username, password, passwordHash)
 	prtgVersion, err := client.GetPrtgVersion()
 	if err != nil {
 		t.Errorf("Unable to get PRTG Version: %v", err)
@@ -160,8 +163,9 @@ func TestGetSensorDetail(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 	var sensorId int64
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 
 	// for sensor id 9182
 	sensorId = 9182
@@ -216,11 +220,12 @@ func TestHistData(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 	var sensorId int64
 	var average int64
 	sDate := time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)
 	eDate := time.Date(2018, time.June, 1, 0, 0, 0, 0, time.UTC)
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 
 	// for sensor id 14254
 	sensorId = 14254
@@ -293,9 +298,10 @@ func TestGetSensorList(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 	var sensorId int64
 	var columns []string
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 
 	// Check sensor list within id 9301
 	sensorId = 9301
@@ -365,9 +371,10 @@ func TestGetDeviceList(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 	var sensorId int64
 	var columns []string
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 
 	// Check sensor list within id 9301
 	sensorId = 9217
@@ -439,9 +446,10 @@ func TestGetGroupList(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 	var sensorId int64
 	var columns []string
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 
 	// Check sensor list within id 9301
 	sensorId = 0
@@ -527,8 +535,9 @@ func TestGetSensorTree(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
+	passwordHash := "passhash"
 	var sensorId int64
-	client := NewClient(server, username, password)
+	client := NewClient(server, username, password, passwordHash)
 
 	// Check sensortree from root (sensorId = 0)
 	{

--- a/prtg-api/prtg_api_test.go
+++ b/prtg-api/prtg_api_test.go
@@ -16,17 +16,35 @@ func TestNewClient(t *testing.T) {
 	server := "http://localhost"
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 
 	// Trying to create new client
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 	if client == nil {
 		t.Error("A new connection object must have been made")
 	}
 
 	// Trying to change the server
 	server = "http://127.0.0.1"
-	client = NewClient(server, username, password, passwordHash)
+	client = NewClient(server, username, password)
+	if client.Server != "http://127.0.0.1" {
+		t.Errorf("Server is %v instead of http://127.0.0.1", client.Server)
+	}
+}
+
+func TestNewClientWithHashedPass(t *testing.T) {
+	server := "http://localhost"
+	username := "user"
+	passwordHash := "passhash"
+
+	// Trying to create new client
+	client := NewClientWithHashedPass(server, username, passwordHash)
+	if client == nil {
+		t.Error("A new connection object must have been made")
+	}
+
+	// Trying to change the server
+	server = "http://127.0.0.1"
+	client = NewClientWithHashedPass(server, username, passwordHash)
 	if client.Server != "http://127.0.0.1" {
 		t.Errorf("Server is %v instead of http://127.0.0.1", client.Server)
 	}
@@ -36,8 +54,7 @@ func TestSetContextTimeout(t *testing.T) {
 	server := "http://localhost"
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// Check whether client contains default context timeout or not.
 	if client.Timeout != 10000 {
@@ -73,7 +90,7 @@ func TestGetCompleteUrl(t *testing.T) {
 	servers := []string{" http://localhost", "localhost"}
 
 	for _, server := range servers {
-		client := NewClient(server, "", "", "")
+		client := NewClient(server, "", "")
 
 		_, err := client.GetPrtgVersion()
 		if err == nil {
@@ -129,8 +146,7 @@ func TestGetPrtgVersion(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 	prtgVersion, err := client.GetPrtgVersion()
 	if err != nil {
 		t.Errorf("Unable to get PRTG Version: %v", err)
@@ -163,9 +179,8 @@ func TestGetSensorDetail(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 	var sensorId int64
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// for sensor id 9182
 	sensorId = 9182
@@ -220,12 +235,11 @@ func TestHistData(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 	var sensorId int64
 	var average int64
 	sDate := time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)
 	eDate := time.Date(2018, time.June, 1, 0, 0, 0, 0, time.UTC)
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// for sensor id 14254
 	sensorId = 14254
@@ -298,10 +312,9 @@ func TestGetSensorList(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 	var sensorId int64
 	var columns []string
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// Check sensor list within id 9301
 	sensorId = 9301
@@ -371,10 +384,9 @@ func TestGetDeviceList(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 	var sensorId int64
 	var columns []string
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// Check sensor list within id 9301
 	sensorId = 9217
@@ -446,10 +458,9 @@ func TestGetGroupList(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 	var sensorId int64
 	var columns []string
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// Check sensor list within id 9301
 	sensorId = 0
@@ -535,9 +546,8 @@ func TestGetSensorTree(t *testing.T) {
 	server := fmt.Sprintf("%v", serverURL)
 	username := "user"
 	password := "pass"
-	passwordHash := "passhash"
 	var sensorId int64
-	client := NewClient(server, username, password, passwordHash)
+	client := NewClient(server, username, password)
 
 	// Check sensortree from root (sensorId = 0)
 	{

--- a/prtg-api/prtg_api_test.go
+++ b/prtg-api/prtg_api_test.go
@@ -157,6 +157,31 @@ func TestGetPrtgVersion(t *testing.T) {
 	}
 }
 
+func TestGetPrtgVersionWithHashedPass(t *testing.T) {
+	mux := new(http.ServeMux)
+	mux.HandleFunc(GetSensorDetailsEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, loadfixture("/prtg_version.json"))
+	})
+	httpServer := setup(mux)
+	defer httpServer.Close()
+	serverURL, _ := url.Parse(httpServer.URL)
+
+	server := fmt.Sprintf("%v", serverURL)
+	username := "user"
+	passwordHash := "pass"
+	client := NewClientWithHashedPass(server, username, passwordHash)
+	prtgVersion, err := client.GetPrtgVersion()
+	if err != nil {
+		t.Errorf("Unable to get PRTG Version: %v", err)
+		return
+	}
+	if prtgVersion != "18.2.41.1636" {
+		t.Errorf("PRTG Version is %v instead of 18.2.41.1636", prtgVersion)
+	}
+}
+
 func TestGetSensorDetail(t *testing.T) {
 	mux := new(http.ServeMux)
 	mux.HandleFunc(GetSensorDetailsEndpoint, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The PRTG API enables the user to pass either a plain-text password, or a
password hash generated by the API. The NewClient function has been
modified to enable the user to pass either a password or a password hash
to the API wrapper.