### PR TITLE
Remove maximum context timeout limitation

### DIFF
--- a/prtg-api/prtg_api.go
+++ b/prtg-api/prtg_api.go
@@ -85,7 +85,7 @@ func NewClientWithHashedPass(server, username, passwordHash string) *Client {
 
 // SetContextTimeout configures the client timeout value in millisecond format.
 func (c *Client) SetContextTimeout(timeout int64) {
-	if (timeout <= 0) || (timeout > 30000) {
+	if timeout <= 0 {
 		c.Timeout = defaultTimeout
 	} else {
 		c.Timeout = timeout

--- a/prtg-api/prtg_api_test.go
+++ b/prtg-api/prtg_api_test.go
@@ -62,9 +62,9 @@ func TestSetContextTimeout(t *testing.T) {
 	}
 
 	// Trying to change the client context timeout more than or equals 30000
-	client.SetContextTimeout(30001)
-	if client.Timeout != 10000 {
-		t.Errorf("client's context timeout is %vms instead of 10s", client.Timeout)
+	client.SetContextTimeout(40000)
+	if client.Timeout != 40000 {
+		t.Errorf("client's context timeout is %vms instead of 40s", client.Timeout)
 	}
 	// Trying to change the client context timeout less than or equals to 30000
 	client.SetContextTimeout(-1)


### PR DESCRIPTION
Hi Haidlir, in my current project, time to retrieve historical data from my customer's PRTG server exceeds more than 50 seconds. I think it's OK to remove the maximum 30 seconds context timeout limitation.
Thanks